### PR TITLE
fix: bar not working below 128/255 opacity

### DIFF
--- a/app/src/androidMain/kotlin/impl/launchEdgeViewJob.kt
+++ b/app/src/androidMain/kotlin/impl/launchEdgeViewJob.kt
@@ -17,6 +17,7 @@ import net.lsafer.edgeseek.app.data.settings.EdgeCorner
 import net.lsafer.edgeseek.app.data.settings.EdgePosData
 import net.lsafer.edgeseek.app.data.settings.EdgeSide
 import net.lsafer.edgeseek.app.data.settings.EdgeSideData
+import kotlin.math.max
 import kotlin.math.roundToInt
 
 private val logger = Logger.withTag("net.lsafer.edgeseek.app.impl.launchEdgeViewJob")
@@ -90,7 +91,7 @@ fun CoroutineScope.launchEdgeViewJob(
                 EdgeCorner.TopRight -> Gravity.TOP or Gravity.RIGHT
                 EdgeCorner.Right -> Gravity.RIGHT or Gravity.CENTER_VERTICAL
             }
-            windowParams.alpha = Color.alpha(posData.color) / 255f
+            windowParams.alpha = max(Color.alpha(posData.color) / 255f, 0.5f) // 0.5f = 128/255
 
             view.setCardBackgroundColor(posData.color)
             view.alpha = Color.alpha(posData.color) / 255f


### PR DESCRIPTION
This is probably a dirty fix but it works for me. Tested on Pixel 9 Pro, latest GrapheneOS (Android 16).

In the code, you're setting the same alpha for both the window parameters and the view.
This means when the color is transparent (alpha = 0), both the window and the view become transparent and apparently on Android 16, transparent windows don't receive touch events.

This fix should ensure that the window itself always has some minimum opacity (at least 128/255) while keeping the actual view transparent.

As I said this is just a dirty fix so feel free to implement this properly if necessary, but this should be the main idea.